### PR TITLE
#1 use proxied subscriber for duplicate subscriber check in all cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>EventBus</name>
     <packaging>jar</packaging>
     <description>A simple but powerful publish-subscribe API that is based on class semantics and/or string (topic) matching.</description>
-    <version>1.4</version>
+    <version>1.4.1-SNAPSHOT</version>
     <url>http://www.eventbus.org</url>
     <scm>
         <url>https://eventbus.dev.java.net/source/browse/eventbus/</url>

--- a/src/org/bushe/swing/event/ThreadSafeEventService.java
+++ b/src/org/bushe/swing/event/ThreadSafeEventService.java
@@ -630,9 +630,7 @@ public class ThreadSafeEventService implements EventService {
             hasEverUsedPrioritized = true;
          }
          isWeakProxySubscriber = proxySubscriber.getReferenceStrength() == ReferenceStrength.WEAK;
-         if (isWeakProxySubscriber) {
-            realSubscriber = ((ProxySubscriber) subscriber).getProxiedSubscriber();
-         }
+         realSubscriber = ((ProxySubscriber) subscriber).getProxiedSubscriber();
       }
       if (isWeakRef && isWeakProxySubscriber) {
          throw new IllegalArgumentException("ProxySubscribers should always be subscribed strongly.");


### PR DESCRIPTION
This will now use the proxied subscriber when checking for duplicate subscribers regardless of the ReferenceStrength of the ProxySubscriber.
